### PR TITLE
Add Injectable object to resource requires explicit binding?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/*
+.idea/*

--- a/src/main/java/com/hubspot/dropwizard/example/MyObj.java
+++ b/src/main/java/com/hubspot/dropwizard/example/MyObj.java
@@ -1,0 +1,11 @@
+package com.hubspot.dropwizard.example;
+
+import com.google.inject.Inject;
+
+public class MyObj {
+
+    @Inject
+    public MyObj() {
+
+    }
+}

--- a/src/main/java/com/hubspot/dropwizard/example/resources/ExampleResource.java
+++ b/src/main/java/com/hubspot/dropwizard/example/resources/ExampleResource.java
@@ -1,5 +1,7 @@
 package com.hubspot.dropwizard.example.resources;
 
+import com.hubspot.dropwizard.example.MyObj;
+
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -10,8 +12,12 @@ import javax.ws.rs.core.MediaType;
 @Produces(MediaType.TEXT_PLAIN)
 public class ExampleResource {
 
+  private MyObj myObj;
+
   @Inject
-  public ExampleResource() {}
+  public ExampleResource(MyObj myObj) {
+    this.myObj = myObj;
+  }
 
   @GET
   public String sayHello() {


### PR DESCRIPTION
By adding a @Inject annotated object to a constructor of the example resource, it throws this error.

```
com.google.inject.CreationException: Unable to create injector, see the following errors:

1) Explicit bindings are required and com.hubspot.dropwizard.example.MyObj is not explicitly bound.
  while locating com.hubspot.dropwizard.example.MyObj
    for the 1st parameter of com.hubspot.dropwizard.example.resources.ExampleResource.<init>(ExampleResource.java:18)
  at com.hubspot.dropwizard.example.ExampleModule.configure(ExampleModule.java:22) (via modules: com.google.inject.util.Modules$CombinedModule -> com.hubspot.dropwizard.example.ExampleModule)

1 error
	at com.google.inject.internal.Errors.throwCreationExceptionIfErrorsExist(Errors.java:470)
	at com.google.inject.internal.InternalInjectorCreator.initializeStatically(InternalInjectorCreator.java:155)
	at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:107)
	at com.google.inject.Guice.createInjector(Guice.java:99)
	at com.google.inject.Guice.createInjector(Guice.java:84)
	at com.hubspot.dropwizard.guicier.GuiceBundle$Builder.lambda$new$0(GuiceBundle.java:152)
	at com.hubspot.dropwizard.guicier.GuiceBundle.run(GuiceBundle.java:106)
	at com.hubspot.dropwizard.guicier.GuiceBundle.run(GuiceBundle.java:34)
	at io.dropwizard.setup.Bootstrap.run(Bootstrap.java:200)
	at io.dropwizard.cli.EnvironmentCommand.run(EnvironmentCommand.java:42)
	at io.dropwizard.cli.ConfiguredCommand.run(ConfiguredCommand.java:87)
	at io.dropwizard.cli.Cli.run(Cli.java:78)
	at io.dropwizard.Application.run(Application.java:93)
	at com.hubspot.dropwizard.example.ExampleApplication.main(ExampleApplication.java:11)
```